### PR TITLE
Bitz hosing mods

### DIFF
--- a/columnphysics/icepack_flux.F90
+++ b/columnphysics/icepack_flux.F90
@@ -60,10 +60,10 @@
                                fswthru_idr, fswthru_idf,&
                                fswthru_uvrdr, fswthru_uvrdf,&
                                fswthru_pardr, fswthru_pardf,&
-                               melttn, meltsn, meltbn, congeln, snoicen, &
+                               melttn, meltsn, meltbn, congeln, snoicen, hsnoicen, &
                                meltt,  melts,        &
                                meltb,  dsnow, dsnown,&
-                               congel,  snoice,      &
+                               congel,  snoice,  hsnoice,    &
                                meltsliq, meltsliqn,  &
                                Uref,     Urefn,      &
                                Qref_iso, Qrefn_iso,  &
@@ -107,6 +107,7 @@
           dsnown  , & ! change in snow depth            (m)
           congeln , & ! congelation ice growth          (m)
           snoicen , & ! snow-ice growth                 (m)
+          hsnoicen , & ! snow-ice growth from hosing    (m)
           dpnd_flushn , & ! pond flushing rate due to ice permeability (m/step)
           dpnd_exponn , & ! exponential pond drainage rate (m/step)
           dpnd_freebdn, & ! pond drainage rate due to freeboard constraint (m/step)
@@ -149,6 +150,7 @@
           meltsliq, & ! mass of snow melt               (kg/m^2)
           congel  , & ! congelation ice growth          (m)
           snoice  , & ! snow-ice growth                 (m)
+          hsnoice  , & ! snow-ice growth from hosing    (m)
           dpnd_flush , & ! pond flushing rate due to ice permeability (m/step)
           dpnd_expon , & ! exponential pond drainage rate (m/step)
           dpnd_freebd, & ! pond drainage rate due to freeboard constraint (m/step)
@@ -283,6 +285,8 @@
          congel    = congel    + congeln   * aicen
       if (present(snoicen) .and. present(snoice)) &
          snoice    = snoice    + snoicen   * aicen
+      if (present(hsnoicen) .and. present(hsnoice)) &
+         hsnoice    = hsnoice    + hsnoicen   * aicen
       ! Meltwater fluxes
       if (tr_pond) then
          if (present(dpnd_flushn)  .and. present(dpnd_flush))   &

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -108,6 +108,7 @@
                                   smice,       massice,   &
                                   smliq,       massliq,   &
                                   congel,      snoice,    &
+                                  HOSE,        hsnoice,   &
                                   mlt_onset,   frz_onset, &
                                   yday,        dsnow,     &
                                   prescribed_ice,         &
@@ -169,7 +170,8 @@
          fbot    , & ! ice-ocean heat flux at bottom surface (W/m^2)
          Tbot    , & ! ice bottom surface temperature (deg C)
          sst     , & ! sea surface temperature (C)
-         sss         ! ocean salinity
+         sss     , & ! ocean salinity
+         HOSE        ! amnt to hose per step in m
 
       ! coupler fluxes to atmosphere
       real (kind=dbl_kind), intent(out):: &
@@ -201,6 +203,7 @@
          meltb    , & ! basal ice melt           (m/step-->cm/day)
          congel   , & ! basal ice growth         (m/step-->cm/day)
          snoice   , & ! snow-ice formation       (m/step-->cm/day)
+         hsnoice  , & ! snow-ice formation from hosing (m/step-->cm/day)
          dsnow    , & ! change in snow thickness (m/step-->cm/day)
          mlt_onset, & ! day of year that sfc melting begins
          frz_onset, & ! day of year that freezing begins (congel or frazil)
@@ -266,6 +269,7 @@
       melts   = c0
       congel  = c0
       snoice  = c0
+      hsnoice  = c0
       dsnow   = c0
       zTsn(:) = c0
       zTin(:) = c0
@@ -334,6 +338,7 @@
                                               flwoutn,   fsurfn,    &
                                               fcondtopn, fcondbotn, &
                                               fadvocn,   snoice,    &
+                                              HOSE,      hsnoice,   &
                                               smice,     smliq,     &
                                               dpnd_flush,dpnd_expon)
             if (icepack_warnings_aborted(subname)) return
@@ -2257,6 +2262,8 @@
                                     melts       , meltsn      , &
                                     congel      , congeln     , &
                                     snoice      , snoicen     , &
+                                    hsnoice     , hsnoicen     , &
+                                    HOSE        , &
                                     dsnow       , dsnown      , &
                                     meltsliq    , meltsliqn   , &
                                     rsnwn       , &
@@ -2277,6 +2284,7 @@
          vvel        , & ! y-component of velocity              (m/s)
          strax       , & ! wind stress components             (N/m^2)
          stray       , & !
+         HOSE        , & ! hosing rate in m
          yday            ! day of year
 
       logical (kind=log_kind), intent(in) :: &
@@ -2318,6 +2326,7 @@
          evapi       , & ! evaporative water flux over ice (kg/m^2/s)
          congel      , & ! basal ice growth         (m/step-->cm/day)
          snoice      , & ! snow-ice formation       (m/step-->cm/day)
+         hsnoice     , & ! snow-ice formation from hosing (m/step-->cm/day)
          Tref        , & ! 2m atm reference temperature           (K)
          Qref        , & ! 2m atm reference spec humidity     (kg/kg)
          Uref        , & ! 10m atm reference wind speed         (m/s)
@@ -2440,7 +2449,8 @@
          melttn      , & ! top ice melt                           (m)
          meltbn      , & ! bottom ice melt                        (m)
          congeln     , & ! congelation ice growth                 (m)
-         snoicen         ! snow-ice growth                        (m)
+         snoicen     , & ! snow-ice growth                        (m)
+         hsnoicen        ! snow-ice growth from hosing            (m)
 
       real (kind=dbl_kind), dimension(:), intent(inout), optional :: &
          dpnd_flushn , & ! category pond flushing rate          (m/step)
@@ -2747,6 +2757,7 @@
          meltbn (n) = c0
          congeln(n) = c0
          snoicen(n) = c0
+         hsnoicen(n) = c0
          l_dpnd_flushn   = c0
          l_dpnd_exponn   = c0
          l_dpnd_freebdn  = c0
@@ -2893,6 +2904,7 @@
                                  smice=smice,         massice=massicen  (:,n), &
                                  smliq=smliq,         massliq=massliqn  (:,n), &
                                  congel=congeln  (n), snoice=snoicen      (n), &
+                                 HOSE = HOSE        , hsnoice=hsnoicen    (n), &
                                  mlt_onset=mlt_onset, frz_onset=frz_onset,     &
                                  yday=yday,           dsnow=l_dsnown         , &
                                  prescribed_ice=prescribed_ice,                &
@@ -3139,8 +3151,10 @@
                                meltbn=meltbn (n), congeln=congeln(n),&
                                meltt=meltt,       melts=melts,      &
                                meltb=meltb,       snoicen=snoicen(n),&
+                               hsnoicen=hsnoicen(n), &
                                dsnow=l_dsnow,     dsnown=l_dsnown,  &
                                congel=congel,     snoice=snoice,    &
+                               hsnoice=hsnoice, &
                                meltsliq=l_meltsliq,                 &
                                meltsliqn=l_meltsliqn(n),            &
                                Uref=Uref,         Urefn=Urefn,      &

--- a/configuration/driver/icedrv_constants.F90
+++ b/configuration/driver/icedrv_constants.F90
@@ -24,6 +24,7 @@
          nu_dump    = 13, &          ! unit for dump file
          nu_forcing = 14, &          ! unit for forcing file
          nu_open_clos = 15, &        ! unit for SHEBA forcing file
+         nu_hosing = 16, &        ! unit for hosing forcing file
          nu_diag    = ice_stdout, &  ! unit for diagnostic output
          nu_diag_out = 103
 

--- a/configuration/driver/icedrv_flux.F90
+++ b/configuration/driver/icedrv_flux.F90
@@ -63,7 +63,8 @@
          dardg2dt, & ! rate of area gain by new ridges (1/s)
          dvirdgdt, & ! rate of ice volume ridged (m/s)
          closing,  & ! rate of closing due to divergence/shear (1/s)
-         opening     ! rate of opening due to divergence/shear (1/s)
+         opening,  & ! rate of opening due to divergence/shear (1/s)
+         hosing      
 
       real (kind=dbl_kind), &
          dimension (nx,ncat), public :: &
@@ -209,7 +210,8 @@
          melttn      , & ! top melt in category n (m)
          meltbn      , & ! bottom melt in category n (m)
          congeln     , & ! congelation ice formation in category n (m)
-         snoicen         ! snow-ice formation in category n (m)
+         snoicen     , & ! snow-ice formation in category n (m)
+         hsnoicen         ! snow-ice formation in category n (m)
 
       real (kind=dbl_kind), dimension (nx,ncat), public :: &
          keffn_top       ! effective thermal conductivity of the top ice layer
@@ -243,6 +245,7 @@
          congel, & ! basal ice growth         (m/step-->cm/day)
          frazil, & ! frazil ice growth        (m/step-->cm/day)
          snoice, & ! snow-ice formation       (m/step-->cm/day)
+         hsnoice, & ! hosing snow-ice formation       (m/step-->cm/day)
          meltt , & ! top ice melt             (m/step-->cm/day)
          melts , & ! snow melt                (m/step-->cm/day)
          meltb , & ! basal ice melt           (m/step-->cm/day)
@@ -688,6 +691,7 @@
       congel (:) = c0
       frazil (:) = c0
       snoice (:) = c0
+      hsnoice (:) = c0
       dsnow  (:) = c0
       meltt  (:) = c0
       melts  (:) = c0

--- a/configuration/driver/icedrv_history.F90
+++ b/configuration/driver/icedrv_history.F90
@@ -50,7 +50,7 @@
       use icedrv_flux, only: evap, fsnow, frain, frazil
       use icedrv_flux, only: fswabs, flw, flwout, fsens, fsurf, flat
       use icedrv_flux, only: Tair, Qa, fsw, fcondtop
-      use icedrv_flux, only: meltt, meltb, meltl, melts, snoice
+      use icedrv_flux, only: meltt, meltb, meltl, melts, snoice, hsnoice
       use icedrv_flux, only: dpnd_flushn, dpnd_exponn, dpnd_freebdn, dpnd_initialn, dpnd_dlidn
       use icedrv_flux, only: dpnd_flush, dpnd_expon, dpnd_freebd, dpnd_initial, dpnd_dlid
       use icedrv_flux, only: dpnd_melt, dpnd_ridge
@@ -85,7 +85,7 @@
       real (kind=dbl_kind),allocatable :: &
          value1(:), value2(:,:), value3(:,:,:), value4(:,:,:,:)  ! temporary
 
-      integer (kind=dbl_kind), parameter :: num_2d = 33
+      integer (kind=dbl_kind), parameter :: num_2d = 34
       character(len=16), parameter :: fld_2d(num_2d) = &
          (/ 'aice            ', 'vice            ', 'vsno            ', &
             'uvel            ', 'vvel            ', 'divu            ', &
@@ -96,6 +96,7 @@
             'frain           ', 'Tair            ', 'Qa              ', &
             'fsw             ', 'fcondtop        ', 'meltt           ', &
             'meltb           ', 'meltl           ', 'snoice          ', &
+            'hsnoice         ', &
             'dsnow           ', 'congel          ', 'sst             ', &
             'sss             ', 'Tf              ', 'fhocn           ', &
             'melts           ' /)
@@ -382,6 +383,7 @@
          if (trim(fld_2d(n)) == 'meltl')    value2(1:count2(1),1) = meltl(1:count2(1))
          if (trim(fld_2d(n)) == 'melts')    value2(1:count2(1),1) = melts(1:count2(1))
          if (trim(fld_2d(n)) == 'snoice')   value2(1:count2(1),1) = snoice(1:count2(1))
+         if (trim(fld_2d(n)) == 'hsnoice')   value2(1:count2(1),1) = hsnoice(1:count2(1))
          if (trim(fld_2d(n)) == 'dsnow')    value2(1:count2(1),1) = dsnow(1:count2(1))
          if (trim(fld_2d(n)) == 'congel')   value2(1:count2(1),1) = congel(1:count2(1))
          if (trim(fld_2d(n)) == 'sst')      value2(1:count2(1),1) = sst(1:count2(1))

--- a/configuration/driver/icedrv_init.F90
+++ b/configuration/driver/icedrv_init.F90
@@ -75,8 +75,8 @@
       use icedrv_flux, only: default_season
       use icedrv_flux, only: sss_fixed, qdp_fixed, hmix_fixed
       use icedrv_forcing, only: precip_units,    fyear_init,      ycycle
-      use icedrv_forcing, only: atm_data_type,   ocn_data_type,   bgc_data_type
-      use icedrv_forcing, only: atm_data_file,   ocn_data_file,   bgc_data_file
+      use icedrv_forcing, only: atm_data_type,   ocn_data_type,   bgc_data_type, hose_data_type
+      use icedrv_forcing, only: atm_data_file,   ocn_data_file,   bgc_data_file, hose_data_file
       use icedrv_forcing, only: ice_data_file
       use icedrv_forcing, only: atm_data_format, ocn_data_format, bgc_data_format
       use icedrv_forcing, only: data_dir
@@ -193,9 +193,9 @@
         default_season,  wave_spec_type,  cpl_frazil,      &
         precip_units,    fyear_init,      ycycle,          &
         atm_data_type,   ocn_data_type,   bgc_data_type,   &
-        lateral_flux_type,                                 &
+        lateral_flux_type, hose_data_type,                 &
         atm_data_file,   ocn_data_file,   bgc_data_file,   &
-        ice_data_file,                                     &
+        ice_data_file,   hose_data_file,                   &
         atm_data_format, ocn_data_format, bgc_data_format, &
         data_dir,        trestore,        restore_ocn,     &
         sss_fixed,       qdp_fixed,       hmix_fixed,      &
@@ -306,7 +306,9 @@
       wave_spec_type  = 'none'    ! type of wave spectrum forcing
       ocn_data_format = 'bin'     ! file format ('bin'=binary or 'nc'=netcdf)
       ocn_data_type   = 'default' ! source of ocean forcing data
+      hose_data_type  = 'default' ! source of hosing forcing data
       ocn_data_file   = ' '       ! ocean forcing data file
+      hose_data_file  = ' '       ! hosing forcing data file
       ice_data_file   = ' '       ! ice forcing data file (opening, closing)
       lateral_flux_type   = 'uniform_ice' ! if 'uniform_ice' assume closing
                                            ! fluxes in uniform ice
@@ -815,11 +817,13 @@
          write(nu_diag,1030) ' atm_data_type             = ', trim(atm_data_type)
          write(nu_diag,1030) ' ocn_data_type             = ', trim(ocn_data_type)
          write(nu_diag,1030) ' bgc_data_type             = ', trim(bgc_data_type)
+         write(nu_diag,1030) ' hose_data_type            = ', trim(hose_data_type)
 
          write(nu_diag,*)    '  lateral_flux_type        = ', trim(lateral_flux_type)
 
          write(nu_diag,1030) ' atm_data_file             = ', trim(atm_data_file)
          write(nu_diag,1030) ' ocn_data_file             = ', trim(ocn_data_file)
+         write(nu_diag,1030) ' hose_data_file            = ', trim(hose_data_file)
          write(nu_diag,1030) ' bgc_data_file             = ', trim(bgc_data_file)
          write(nu_diag,1030) ' ice_data_file             = ', trim(ice_data_file)
          write(nu_diag,1010) ' precalc_forc              = ', precalc_forc

--- a/configuration/driver/icedrv_step.F90
+++ b/configuration/driver/icedrv_step.F90
@@ -115,7 +115,7 @@
       use icedrv_domain_size, only: ncat, nilyr, nslyr, n_aero, n_iso, nfsd, nx
       use icedrv_flux, only: frzmlt, sst, Tf, strocnxT, strocnyT, rsiden, wlat, &
                              fbot, Tbot, Tsnice
-      use icedrv_flux, only: meltsn, melttn, meltbn, congeln, snoicen, uatm, vatm
+      use icedrv_flux, only: meltsn, melttn, meltbn, congeln, snoicen, hsnoicen, uatm, vatm
       use icedrv_flux, only: wind, rhoa, potT, Qa, Qa_iso, zlvl, strax, stray, flatn
       use icedrv_flux, only: fsensn, fsurfn, fcondtopn, fcondbotn
       use icedrv_flux, only: flw, fsnow, fpond, sss, mlt_onset, frz_onset, fsloss
@@ -123,7 +123,7 @@
       use icedrv_flux, only: fcondtop, fcondbot, fsens, fresh, fsalt, fhocn
       use icedrv_flux, only: flat, fswabs, flwout, evap, evaps, evapi
       use icedrv_flux, only: Tref, Qref, Qref_iso, Uref
-      use icedrv_flux, only: meltt, melts, meltb, congel, snoice
+      use icedrv_flux, only: meltt, melts, meltb, congel, snoice, hsnoice
       use icedrv_flux, only: fswthru, fswthru_vdr, fswthru_vdf, fswthru_idr, fswthru_idf
       use icedrv_flux, only: flatn_f, fsensn_f, fsurfn_f, fcondtopn_f
       use icedrv_flux, only: dsnow, dsnown, faero_atm, faero_ocn
@@ -134,7 +134,8 @@
       use icedrv_init, only: lmask_n, lmask_s
       use icedrv_state, only: aice, aicen, aice_init, aicen_init, vicen_init
       use icedrv_state, only: vice, vicen, vsno, vsnon, trcrn, uvel, vvel, vsnon_init
-
+      use icedrv_flux, only: hosing
+      
       ! column packge includes
       use icepack_intfc, only: icepack_step_therm1
 
@@ -169,7 +170,7 @@
          rsnwn, smicen, smliqn
 
       real (kind=dbl_kind) :: &
-         puny
+         puny, HOSE
 
       character(len=*), parameter :: subname='(step_therm1)'
 
@@ -273,6 +274,7 @@
           enddo
         endif ! snwgrain
 
+        HOSE = dt*hosing(i)
         call icepack_step_therm1(dt=dt, &
             aicen_init = aicen_init(i,:), &
             vicen_init = vicen_init(i,:), &
@@ -370,6 +372,8 @@
             melts    = melts(i),      meltsn    = meltsn(i,:),    &
             congel   = congel(i),     congeln   = congeln(i,:),   &
             snoice   = snoice(i),     snoicen   = snoicen(i,:),   &
+            hsnoice  = hsnoice(i),    hsnoicen  = hsnoicen(i,:),   &
+            HOSE     = HOSE, &
             dsnow    = dsnow(i),      dsnown    = dsnown(i,:),    &
             meltsliqn= meltsliqn(i,:), &
             afsdn         = trcrn       (i,nt_fsd:nt_fsd+nfsd-1,:), &


### PR DESCRIPTION
## PR checklist
- [x] Short (1 sentence) summary of your PR: 
  Introduces the ability to flood the sea ice surface with sea water by calculating thickness changes due to snow-ice formation as a function of a prescribed rate of flooding.
- [x] Developer(s): 
    Cecilia M. Bitz
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [x] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [x] Yes
        - [ ] No 
- [x] Please document the changes in detail, including _why_ the changes are made.  This will become part of the PR commit log.
The modifications in this pull request enable a sea ice flooding implementation used by Pauling & Bitz (2021) to represent a deployment of Arctic Ice Management. The code changes reflect an input data file with an hourly (?) prescribed flooding rate per timestep, which is then converted to a sea ice thickness change as a function of the snow-ice formation due to the flooding. I've included these modifications in this branch to compare this implementation to the surface heat and mass flux implementation used by Zampieri & Goessling (2019) in the FESOM sea ice model. 
